### PR TITLE
アイテムリストのストレージを抽象化する。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 item/
 *.csv
 setting.ini
+.mypy_cache/

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -1,0 +1,34 @@
+from typing import Dict
+
+import numpy as np  # type: ignore
+
+
+class CannotCreateItemError(Exception):
+    """
+        アイテムを新規に作ることができないことを示す例外
+    """
+    pass
+
+
+class Storage:
+    """
+        抽象化されたストレージ層。
+        具体的な実装は、このクラスで定義されたメソッドを実装して
+        いることが義務付けられる。
+
+        利用者がこのクラスを直接用いることはできない。
+        あくまでストレージ層が守るべき契約を定めたものである。
+    """
+    def known_item_dict(self) -> Dict[str, np.ndarray]:
+        """
+            既知のアイテムを辞書形式で返す。
+            {アイテム名: im (OpenCV の画像オブジェクト), ...}
+        """
+        raise NotImplementedError
+
+    def create_item(self, im: np.ndarray) -> str:
+        """
+            im (OpenCV の画像オブジェクト) を受け取って永続化し、
+            新たに割り当てられたアイテム名を返す。
+        """
+        raise NotImplementedError

--- a/storage/filesystem.py
+++ b/storage/filesystem.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from typing import Dict
+
+import cv2  # type: ignore
+import numpy as np  # type:ignore
+
+from . import CannotCreateItemError
+
+
+class FileSystemStorage:
+    """
+        ファイルシステムを用いた Storage
+    """
+    def __init__(self, itemdir: Path):
+        # TODO: itemdir.mkdir(exist_ok=True) だと GAE でエラーになる。
+        # GAE は readonly filesystem であるため。少なくとも GAE 向けの
+        # 実装を FileSystemStorage 非依存にするまではこの実装でないと
+        # まずい。
+        if not itemdir.exists():
+            itemdir.mkdir(parents=True)
+        self.itemdir = itemdir
+
+    def known_item_dict(self) -> Dict[str, np.ndarray]:
+        items = {}
+        files = self.itemdir.glob('**/*.png')
+        for f in files:
+            im = self._imread(str(f))
+            if im is not None:
+                items[f.stem] = im
+        return items
+
+    def _imread(self,
+                filename: str,
+                flags: int = cv2.IMREAD_COLOR,
+                dtype: float = np.uint8) -> np.ndarray:
+        n = np.fromfile(filename, dtype)
+        return cv2.imdecode(n, flags)
+
+    def create_item(self, im: np.ndarray) -> str:
+        for i in range(1, 100000):
+            itemfile = self.itemdir / ('item{:0=6}'.format(i) + '.png')
+            if itemfile.is_file():
+                continue
+
+            im_gray = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)
+            cv2.imwrite(itemfile.as_posix(), im_gray)
+            return itemfile.stem
+
+        raise CannotCreateItemError('unable to allocate a resource')

--- a/storage/test_filesystem.py
+++ b/storage/test_filesystem.py
@@ -1,0 +1,48 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import cv2  # type: ignore
+import numpy as np  # type: ignore
+
+from .filesystem import FileSystemStorage
+
+
+class FileSystemStorageTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.itemdir = Path(str(self.tempdir))
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_known_item_dict(self):
+        st = FileSystemStorage(self.itemdir)
+        im1 = self.make_random_cv2_image()
+        ret1 = st.create_item(im1)
+        im2 = self.make_random_cv2_image()
+        ret2 = st.create_item(im2)
+
+        (self.itemdir / 'item000001.png').replace(self.itemdir / 'test1.png')
+        (self.itemdir / 'item000002.png').replace(self.itemdir / 'test2.png')
+
+        d = st.known_item_dict()
+        self.assertEqual(len(d), 2)
+        for v in d.values():
+            self.assertTrue(isinstance(v, np.ndarray))
+
+    def test_create_item(self):
+        st = FileSystemStorage(self.itemdir)
+        im1 = self.make_random_cv2_image()
+        ret1 = st.create_item(im1)
+        self.assertEqual(ret1, 'item000001')
+        im2 = self.make_random_cv2_image()
+        ret2 = st.create_item(im2)
+        self.assertEqual(ret2, 'item000002')
+        im3 = self.make_random_cv2_image()
+        ret3 = st.create_item(im3)
+        self.assertEqual(ret3, 'item000003')
+
+    def make_random_cv2_image(self):
+        return np.random.randint(255, size=(128, 128, 3), dtype=np.uint8)

--- a/storage/test_filesystem.py
+++ b/storage/test_filesystem.py
@@ -28,7 +28,7 @@ class FileSystemStorageTest(unittest.TestCase):
         (self.itemdir / 'item000002.png').replace(self.itemdir / 'test2.png')
 
         d = st.known_item_dict()
-        self.assertEqual(len(d), 2)
+        self.assertListEqual(sorted(d.keys()), ['test1', 'test2'])
         for v in d.values():
             self.assertTrue(isinstance(v, np.ndarray))
 


### PR DESCRIPTION
既存の `Item_dir` に対する操作を以下のように抽象化しました。

- 「アイテムディレクトリ内のアイテム一覧を取得する処理」を抽象化して「ストレージが持つアイテム一覧を返す」にしました。 `storage.Storage` クラスの `known_item_dict(self)` メソッドがこれに対応。
- 「未知のアイテムに新しいファイル名 (例 `item000001.png`) を与えて保存する処理」を抽象化して「未知のアイテムをストレージに登録する」にしました。 `storage.Storage` クラスの `create_item(self, im)` メソッドがこれに対応。

具体的な実装として `storage.FileSystemStorage` を用意しました。これを用いて、既存ソフトウェアの動作を壊さずに Storage の概念を導入します。今後は `storage.Storage` が定める規約 (`known_item_dict` と `create_item` メソッドを実装すること) に従う限り、新しい `storage.Storage` クラスの実装を追加していくことができます。