### PR TITLE
デフォルトで debug が有効になってしまう問題を修正。

### DIFF
--- a/img2str.py
+++ b/img2str.py
@@ -248,7 +248,7 @@ class DropItems:
 class ScreenShot:
     unknown_item_count = 0
 
-    def __init__(self, img_rgb, svm, dropitems, debug="False"):
+    def __init__(self, img_rgb, svm, dropitems, debug=False):
         # TRAINING_IMG_WIDTHは3840x2160の解像度をベースにしている
         TRAINING_IMG_WIDTH = 1514
         threshold = 80


### PR DESCRIPTION
`"False"` は False として評価されないため、常にデバッグが有効になります。
この問題を修正します。

```
Python 3.6.9 (default, Nov  7 2019, 10:44:02)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> if not "False": print("ok")
...
>>> if not False: print("ok")
...
ok
>>>
```