### PR TITLE
ドロップをFGO周回カウンタ形式に変換する処理を再実装。

### DIFF
--- a/fgosccalc.py
+++ b/fgosccalc.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
+import argparse
+import dataclasses
+import logging
 import sys
 import cv2
 import numpy as np
 from pathlib import Path
 from collections import Counter
+from typing import Dict
+
 import img2str
+
+logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+logger = logging.getLogger(__name__)
 
 
 def make_diff(itemlist1, itemlist2):
@@ -31,11 +39,11 @@ def make_diff(itemlist1, itemlist2):
 #順番ルールにも使われる
 # 通常 弓→槍の順番だが、種火のみ槍→弓の順番となる
 # 同じレアリティの中での順番ルールは不明
-std_item = ['実', 'カケラ', '卵', '鏡','炉心', '神酒', '胆石', '産毛', 'スカラベ',    
-    'ランプ', '幼角', '根', '逆鱗', '心臓', '爪', '脂', '涙石' , 
-    '霊子', '冠', '矢尻', '鈴', 'オーロラ',  '指輪', '結氷', '勾玉','貝殻', '勲章', 
+std_item = ['実', 'カケラ', '卵', '鏡', '炉心', '神酒', '胆石', '産毛', 'スカラベ',
+    'ランプ', '幼角', '根', '逆鱗', '心臓', '爪', '脂', '涙石' ,
+    '霊子', '冠', '矢尻', '鈴', 'オーロラ', '指輪', '結氷', '勾玉','貝殻', '勲章',
     '種', 'ランタン', '八連', '宝玉', '羽根', '頁', '歯車', 'ホム', '蹄鉄',
-    '火薬', '鉄杭', '髄液', '毒針', '鎖', '塵', '牙', '骨', '証', 
+    '火薬', '鉄杭', '髄液', '毒針', '鎖', '塵', '牙', '骨', '証',
     '剣秘', '弓秘', '槍秘', '騎秘', '術秘', '殺秘', '狂秘',
     '剣魔', '弓魔', '槍魔', '騎魔', '術魔', '殺魔', '狂魔',
     '剣輝', '弓輝', '槍輝', '騎輝', '術輝', '殺輝', '狂輝',
@@ -69,18 +77,149 @@ tanebi_list = [ '全種火', '全灯火', '全大火', '"全猛火','全業火',
                 '狂種火', '狂灯火', '狂大火', '狂猛火', '狂業火']
 
 
-if __name__ == '__main__':
-    dropitems = img2str.DropItems()        
-    svm = cv2.ml.SVM_load(str(img2str.training))
-    file1 = Path(sys.argv[1])
-    img_rgb = img2str.imread(str(file1))
-    sc1 = img2str.ScreenShot(img_rgb, svm, dropitems)
+def sorted_dict(d, key):
+    keys = sorted(d, key=key)
+    nd = {}
+    for key in keys:
+        nd[key] = d[key]
+    return nd
 
-    file2 = Path(sys.argv[2])
-    img_rgb = img2str.imread(str(file2))
-    sc2 = img2str.ScreenShot(img_rgb, svm, dropitems)
 
-    newdic = make_diff(sc1.itemlist, sc2.itemlist)
+@dataclasses.dataclass
+class ParsedDropsDiff:
+    """
+        DropsDiff を
+         - 素材 materials
+         - スキル石 gems
+         - ピースモニュメント pieces
+         - 種火 wisdoms
+         - 非恒常アイテム non_standards
+        に分解したもの。
+
+        FIXME この対応では不完全。
+        イベント時は非恒常アイテムをさらに
+        礼装、イベント素材に分類し、並び順を
+        - 礼装
+        - 素材
+        - スキル石
+        - ピースモニュメント
+        - 種火
+        - イベント素材
+        としなければいけない。
+        礼装とイベント素材を正しく並べるには、外部からアイテム名とソート順序を与えるしかない。
+    """
+    questname: str
+    materials: Dict[str, int]
+    gems: Dict[str, int]
+    pieces: Dict[str, int]
+    wisdoms: Dict[str, str]
+    non_standards: Dict[str, int]
+
+    def as_syukai_counter(self):
+        """
+            周回カウンタ報告形式の文字列を返す
+        """
+        def format(item_dict):
+            return '-'.join(['{}{}'.format(name, count) for name, count in item_dict.items()])
+
+        def add_line(item_dict, lines):
+            line = format(item_dict)
+            if line:
+                lines.append(line)
+
+        lines = []
+        add_line(self.materials, lines)
+        add_line(self.gems, lines)
+        add_line(self.pieces, lines)
+        add_line(self.wisdoms, lines)
+        add_line(self.non_standards, lines)
+
+        questname = self.questname
+        if not questname:
+            questname = '(クエスト名)'
+        body = '\n'.join(lines)
+
+        return f"""
+【{questname}】000周
+{body}
+#FGO周回カウンタ http://aoshirobo.net/fatego/rc/
+""".lstrip()
+
+
+class DropsDiff:
+    def __init__(self, item_dict, questname, questdrops):
+        """
+            item_dict: make_diff() で求めたドロップ差分情報の辞書
+            questname: get_questinfo() で求めたフリークエスト名
+            questdrops: get_questinfo() で求めたフリークエストのドロップリスト
+        """
+        self.item_dict = item_dict
+        self.questname = questname
+        self.questdrops = questdrops
+        self.is_freequest = self.questname is not None and len(self.questname) > 0
+
+    def validate_dropitems(self):
+        for name in self.item_dict:
+            if name not in self.questdrops:
+                return False
+        return True
+
+    def parse(self):
+        """
+            素材、スキル石、モニュピ、種火に分解した結果を返す。
+        """
+        non_standards = {}
+        materials = {}
+        gems = {}
+        pieces = {}
+        wisdoms = {}
+
+        for name, count in self.item_dict.items():
+            if name not in std_item:
+                non_standards[name] = count
+            elif name in skillstone_list:
+                gems[name] = count
+            elif name in monyupi_list:
+                pieces[name] = count
+            elif name in tanebi_list:
+                raise ValueError('item_dict should not have wisdoms')
+            else:
+                materials[name] = count
+
+        if self.is_freequest:
+            for questdrop in self.questdrops:
+                if questdrop in tanebi_list:
+                    # 種火はスクリーンショットから個数計算できないため常に
+                    # NaN (N/A の意味。FGO周回カウンタ互換) を設定する
+                    wisdoms[questdrop] = 'NaN'
+
+        return ParsedDropsDiff(
+            self.questname,
+            non_standards,
+            sorted_dict(materials, key=lambda s: std_item.index(s)),
+            sorted_dict(gems, key=lambda s: skillstone_list.index(s)),
+            sorted_dict(pieces, key=lambda s: monyupi_list.index(s)),
+            sorted_dict(wisdoms, key=lambda s: tanebi_list.index(s)),
+        )
+
+
+def get_questinfo(sc1, sc2):
+    sc1qname = sc1.quest_output
+    sc2qname = sc2.quest_output
+    logger.debug('sc1 quest: %s %s', sc1qname, getattr(sc1, 'droplist', None))
+    logger.debug('sc2 quest: %s %s', sc2qname, getattr(sc2, 'droplist', None))
+    if not sc1qname:
+        return '', ''
+    if sc1qname != sc2qname:
+        return '', ''
+    return sc1qname, getattr(sc2, 'droplist', [])
+
+
+def _print_as_syukai_counter(newdic, dropitems, sc1, sc2):
+    """
+        旧実装
+        FGO 周回カウンタ報告形式で出力する
+    """
     std_item_dic = {}
     for i in std_item:
         std_item_dic[dropitems.normalize_item(i)] = 0
@@ -135,3 +274,78 @@ if __name__ == '__main__':
         output = output[:-1]
     print(output)
     print("#FGO周回カウンタ http://aoshirobo.net/fatego/rc/")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'sc1',
+        help='1st screenshot',
+    )
+    parser.add_argument(
+        'sc2',
+        help='2nd screenshot',
+    )
+    parser.add_argument(
+        '--loglevel',
+        choices=('DEBUG', 'INFO', 'WARNING'),
+        default='INFO',
+        help='loglevel [default: INFO]',
+    )
+    parser.add_argument(
+        '--output',
+        type=argparse.FileType('w'),
+        default=sys.stdout,
+        help='output file [default: STDOUT]',
+    )
+    parser.add_argument(
+        '--future',
+        action='store_true',
+    )
+    return parser.parse_args()
+
+
+def main(args):
+    dropitems = img2str.DropItems()
+    svm = cv2.ml.SVM_load(str(img2str.training))
+    file1 = Path(args.sc1)
+    img_rgb = img2str.imread(str(file1))
+    sc1 = img2str.ScreenShot(img_rgb, svm, dropitems)
+
+    file2 = Path(args.sc2)
+    img_rgb = img2str.imread(str(file2))
+    sc2 = img2str.ScreenShot(img_rgb, svm, dropitems)
+
+    logger.debug('sc1: %s', sc1.itemlist)
+    logger.debug('sc2: %s', sc2.itemlist)
+
+    newdic = make_diff(sc1.itemlist, sc2.itemlist)
+
+    if args.future:
+        # 新ロジック
+        logger.info('use new DropsDiff algorism')
+        questname, droplist = get_questinfo(sc1, sc2)
+
+        logger.debug('questname: %s', questname)
+        logger.debug('questdrop: %s', droplist)
+
+        obj = DropsDiff(newdic, questname, droplist)
+        is_valid = obj.validate_dropitems()
+        parsed_obj = obj.parse()
+        output = parsed_obj.as_syukai_counter()
+
+        if not is_valid:
+            logger.error('スクリーンショットからクエストを特定できません')
+            logger.error(output)
+            sys.exit(1)
+        else:
+            args.output.write(output)
+    else:
+        # 旧ロジック
+        _print_as_syukai_counter(newdic, dropitems, sc1, sc2)
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    logger.setLevel(args.loglevel)
+    main(args)


### PR DESCRIPTION
新実装の検証が十分でないため、旧実装は引き続き残してあります。
実行時オプションで `--future` を与えると、新実装によるFGO周回カウンタ形式変換処理が実行されます。このオプションを与えない場合は旧実装が使われます。